### PR TITLE
Implement OAuth Authentication with Supabase and Expo

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,7 +4,7 @@
     "slug": "fitness-app",
     "version": "1.0.0",
 
-    "scheme": "fitness-app",
+    "scheme": "fitnessapp",
     "web": {
       "bundler": "metro",
       "output": "static",
@@ -30,13 +30,15 @@
     },
     "assetBundlePatterns": ["**/*"],
     "ios": {
-      "supportsTablet": true
+      "supportsTablet": true,
+      "bundleIdentifier": "com.fitnessapp"
     },
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"
-      }
+      },
+      "package": "com.fitnessapp"
     },
     "developmentClient": {
       "silentLaunch": {

--- a/app/+not-found.tsx
+++ b/app/+not-found.tsx
@@ -19,5 +19,5 @@ const styles = {
   container: `items-center flex-1 justify-center p-5`,
   title: `text-xl font-bold`,
   link: `mt-4 pt-4`,
-  linkText: `text-base text-[#2e78b7]`,
+  linkText: `text-base text-[#2e78b7]`
 };

--- a/app/auth/callback.tsx
+++ b/app/auth/callback.tsx
@@ -1,0 +1,48 @@
+import { useRouter } from 'expo-router';
+import { useEffect } from 'react';
+import { View, ActivityIndicator, Text } from 'react-native';
+
+import { useAuthStore } from '../../store/auth';
+import { supabase } from '../../utilities/supabase';
+
+export default function AuthCallback() {
+  const router = useRouter();
+  const { setError } = useAuthStore();
+
+  useEffect(() => {
+    // Handle the OAuth callback
+    const handleOAuthCallback = async () => {
+      try {
+        // The URL params will be automatically handled by Supabase Auth
+        // We just need to check if the session exists
+        const { data, error } = await supabase.auth.getSession();
+
+        if (error) {
+          throw error;
+        }
+
+        if (data?.session) {
+          // Session exists, redirect to home
+          router.replace('/(tabs)');
+        } else {
+          // No session, redirect to login
+          setError('Authentication failed. Please try again.');
+          router.replace('/auth');
+        }
+      } catch (error: any) {
+        console.error('Error in OAuth callback:', error);
+        setError(error.message || 'Authentication failed');
+        router.replace('/auth');
+      }
+    };
+
+    handleOAuthCallback();
+  }, [router, setError]);
+
+  return (
+    <View className="flex-1 items-center justify-center bg-white">
+      <ActivityIndicator size="large" color="#3B82F6" />
+      <Text className="mt-4 text-gray-600">Completing authentication...</Text>
+    </View>
+  );
+}

--- a/app/auth/index.tsx
+++ b/app/auth/index.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from '@i18n/core';
 import { useAuthStore } from '@store/auth';
 import { LinearGradient } from 'expo-linear-gradient';
 import { router } from 'expo-router';
+import * as WebBrowser from 'expo-web-browser';
 import React, { useEffect } from 'react';
 import {
   View,
@@ -15,6 +16,11 @@ import {
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
+import { supabase } from '../../utilities/supabase';
+
+// Required for OAuth in Expo
+WebBrowser.maybeCompleteAuthSession();
+
 export default function LoginScreen() {
   const { t } = useTranslation();
   const insets = useSafeAreaInsets();
@@ -22,7 +28,7 @@ export default function LoginScreen() {
   const isTablet = width > 768;
 
   // Get auth state from store
-  const { isAuthenticated, isLoading } = useAuthStore();
+  const { isAuthenticated, isLoading, setError } = useAuthStore();
 
   // Redirect to tabs if already authenticated
   useEffect(() => {
@@ -41,24 +47,34 @@ export default function LoginScreen() {
   }
 
   const handleAppleSignIn = async () => {
-    // Implement Apple Sign In with Supabase
     try {
-      // For now, this is a placeholder
-      // Will be implemented in the future
-      console.log('Apple Sign In pressed');
-    } catch (error) {
+      const { error } = await supabase.auth.signInWithOAuth({
+        provider: 'apple',
+        options: {
+          redirectTo: 'fitnessapp://auth/callback'
+        }
+      });
+
+      if (error) throw error;
+    } catch (error: any) {
       console.error('Error signing in with Apple:', error);
+      setError(error.message || 'Failed to sign in with Apple');
     }
   };
 
   const handleGoogleSignIn = async () => {
-    // Implement Google Sign In with Supabase
     try {
-      // For now, this is a placeholder
-      // Will be implemented in the future
-      console.log('Google Sign In pressed');
-    } catch (error) {
+      const { error } = await supabase.auth.signInWithOAuth({
+        provider: 'google',
+        options: {
+          redirectTo: 'fitnessapp://auth/callback'
+        }
+      });
+
+      if (error) throw error;
+    } catch (error: any) {
       console.error('Error signing in with Google:', error);
+      setError(error.message || 'Failed to sign in with Google');
     }
   };
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -5,6 +5,6 @@ module.exports = function (api) {
   return {
     presets: [['babel-preset-expo', { jsxImportSource: 'nativewind' }], 'nativewind/babel'],
 
-    plugins,
+    plugins
   };
 };

--- a/i18n/config.ts
+++ b/i18n/config.ts
@@ -10,17 +10,17 @@ i18next.use(initReactI18next).init({
   compatibilityJSON: 'v4',
   resources: {
     en: {
-      translation: en,
+      translation: en
     },
     es: {
-      translation: es,
-    },
+      translation: es
+    }
   },
   lng: 'en', // Default language
   fallbackLng: 'en',
   interpolation: {
-    escapeValue: false, // React already escapes values
-  },
+    escapeValue: false // React already escapes values
+  }
 });
 
 export default i18next;

--- a/i18n/locales/en/index.ts
+++ b/i18n/locales/en/index.ts
@@ -5,5 +5,5 @@ import settings from './settings';
 export default {
   common,
   navigation,
-  settings,
+  settings
 };

--- a/i18n/locales/en/navigation.ts
+++ b/i18n/locales/en/navigation.ts
@@ -4,7 +4,7 @@ export default {
     workout: 'Workout',
     nutrition: 'Nutrition',
     stats: 'Stats',
-    chat: 'Chat',
+    chat: 'Chat'
   },
-  settings: 'Settings',
+  settings: 'Settings'
 };

--- a/i18n/locales/en/settings.ts
+++ b/i18n/locales/en/settings.ts
@@ -4,25 +4,25 @@ export default {
     title: 'Language',
     english: 'English',
     spanish: 'Spanish',
-    selectLanguage: 'Select language',
+    selectLanguage: 'Select language'
   },
   appearance: {
     title: 'Appearance',
     darkMode: 'Dark Mode',
     lightMode: 'Light Mode',
-    systemDefault: 'System Default',
+    systemDefault: 'System Default'
   },
   account: {
     title: 'Account',
     profile: 'Profile',
     security: 'Security',
-    notifications: 'Notifications',
+    notifications: 'Notifications'
   },
   about: {
     title: 'About',
     version: 'Version',
     termsOfService: 'Terms of Service',
-    privacyPolicy: 'Privacy Policy',
+    privacyPolicy: 'Privacy Policy'
   },
-  logout: 'Logout',
+  logout: 'Logout'
 };

--- a/i18n/locales/es/index.ts
+++ b/i18n/locales/es/index.ts
@@ -5,5 +5,5 @@ import settings from './settings';
 export default {
   common,
   navigation,
-  settings,
+  settings
 };

--- a/i18n/locales/es/navigation.ts
+++ b/i18n/locales/es/navigation.ts
@@ -4,7 +4,7 @@ export default {
     workout: 'Entrenamiento',
     nutrition: 'Nutrición',
     stats: 'Estadísticas',
-    chat: 'Chat',
+    chat: 'Chat'
   },
-  settings: 'Configuración',
+  settings: 'Configuración'
 };

--- a/i18n/locales/es/settings.ts
+++ b/i18n/locales/es/settings.ts
@@ -4,25 +4,25 @@ export default {
     title: 'Idioma',
     english: 'Inglés',
     spanish: 'Español',
-    selectLanguage: 'Seleccionar idioma',
+    selectLanguage: 'Seleccionar idioma'
   },
   appearance: {
     title: 'Apariencia',
     darkMode: 'Modo Oscuro',
     lightMode: 'Modo Claro',
-    systemDefault: 'Predeterminado del Sistema',
+    systemDefault: 'Predeterminado del Sistema'
   },
   account: {
     title: 'Cuenta',
     profile: 'Perfil',
     security: 'Seguridad',
-    notifications: 'Notificaciones',
+    notifications: 'Notificaciones'
   },
   about: {
     title: 'Acerca de',
     version: 'Versión',
     termsOfService: 'Términos de Servicio',
-    privacyPolicy: 'Política de Privacidad',
+    privacyPolicy: 'Política de Privacidad'
   },
-  logout: 'Cerrar Sesión',
+  logout: 'Cerrar Sesión'
 };

--- a/store/auth/index.ts
+++ b/store/auth/index.ts
@@ -1,77 +1,14 @@
+import { saveTokens, clearTokens, saveUser, getUser, clearUser } from '@utilities/storage';
+import { supabase } from '@utilities/supabase';
 import {
-  saveTokens,
-  getTokens,
-  clearTokens,
-  saveUser,
-  getUser,
-  clearUser
-} from '@utilities/storage';
+  extractUserData,
+  saveSessionData,
+  getCurrentSession,
+  refreshSession
+} from '@utilities/supabase/session';
 import { create } from 'zustand';
 
-import { AuthState, AuthStore, User } from './types';
-
-// Mock API functions - replace with actual API calls in production
-const mockLogin = async (
-  email: string,
-  password: string
-): Promise<{ user: User; tokens: { access: string; refresh: string } }> => {
-  // Simulate API delay
-  await new Promise((resolve) => setTimeout(resolve, 1000));
-
-  // Mock validation
-  if (email !== 'user@example.com' || password !== 'password') {
-    throw new Error('Invalid credentials');
-  }
-
-  return {
-    user: {
-      id: '1',
-      email,
-      name: 'Demo User'
-    },
-    tokens: {
-      access: 'mock-access-token',
-      refresh: 'mock-refresh-token'
-    }
-  };
-};
-
-const mockSignUp = async (
-  email: string,
-  password: string,
-  name?: string
-): Promise<{ user: User; tokens: { access: string; refresh: string } }> => {
-  // Simulate API delay
-  await new Promise((resolve) => setTimeout(resolve, 1000));
-
-  return {
-    user: {
-      id: '2',
-      email,
-      name: name || 'New User'
-    },
-    tokens: {
-      access: 'mock-access-token-new',
-      refresh: 'mock-refresh-token-new'
-    }
-  };
-};
-
-const mockRefreshToken = async (
-  refreshToken: string
-): Promise<{ access: string; refresh: string }> => {
-  // Simulate API delay
-  await new Promise((resolve) => setTimeout(resolve, 500));
-
-  if (!refreshToken) {
-    throw new Error('Invalid refresh token');
-  }
-
-  return {
-    access: 'new-mock-access-token',
-    refresh: 'new-mock-refresh-token'
-  };
-};
+import { AuthState, AuthStore } from './types';
 
 // Initial state
 const initialState: AuthState = {
@@ -92,28 +29,25 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
     try {
       set({ isLoading: true });
 
-      // Get tokens from secure storage
-      const { accessToken, refreshToken } = await getTokens();
+      // Check for existing session in Supabase
+      const session = await getCurrentSession();
 
-      if (accessToken && refreshToken) {
-        // Get user data from secure storage
-        const userData = await getUser();
+      if (session) {
+        // Get user data from secure storage or create from session
+        let userData = await getUser();
+
+        if (!userData && session.user) {
+          userData = extractUserData(session.user);
+          await saveUser(userData);
+        }
 
         if (userData) {
           set({
             isAuthenticated: true,
             user: userData,
-            accessToken,
-            refreshToken
+            accessToken: session.access_token,
+            refreshToken: session.refresh_token
           });
-        } else {
-          // If we have tokens but no user data, try to refresh tokens
-          const success = await get().refreshTokens();
-          if (!success) {
-            // Clear everything if refresh fails
-            await clearTokens();
-            await clearUser();
-          }
         }
       }
     } catch (error) {
@@ -128,19 +62,34 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
     try {
       set({ isLoading: true, error: null });
 
-      // Call login API (mock for now)
-      const { user, tokens } = await mockLogin(email, password);
+      // Call Supabase login
+      const { data, error } = await supabase.auth.signInWithPassword({
+        email,
+        password
+      });
 
-      // Save tokens and user data
-      await saveTokens(tokens.access, tokens.refresh);
-      await saveUser(user);
+      if (error) throw error;
+
+      // Extract user and session
+      const { user, session } = data;
+
+      if (!user || !session) {
+        throw new Error('Login failed: No user or session returned');
+      }
+
+      // Create user object and save session data
+      const userData = await saveSessionData(session);
+
+      if (!userData) {
+        throw new Error('Failed to save user data');
+      }
 
       // Update state
       set({
         isAuthenticated: true,
-        user,
-        accessToken: tokens.access,
-        refreshToken: tokens.refresh,
+        user: userData,
+        accessToken: session.access_token,
+        refreshToken: session.refresh_token,
         error: null
       });
     } catch (error: any) {
@@ -156,19 +105,48 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
     try {
       set({ isLoading: true, error: null });
 
-      // Call signup API (mock for now)
-      const { user, tokens } = await mockSignUp(email, password, name);
+      // Call Supabase signup
+      const { data, error } = await supabase.auth.signUp({
+        email,
+        password,
+        options: {
+          data: {
+            name: name || email.split('@')[0]
+          }
+        }
+      });
 
-      // Save tokens and user data
-      await saveTokens(tokens.access, tokens.refresh);
-      await saveUser(user);
+      if (error) throw error;
+
+      // Extract user and session
+      const { user, session } = data;
+
+      if (!user) {
+        throw new Error('Sign up failed: No user returned');
+      }
+
+      // If email confirmation is required, session might be null
+      if (!session) {
+        set({
+          isLoading: false,
+          error: 'Please check your email to confirm your account'
+        });
+        return;
+      }
+
+      // Save session data
+      const userData = await saveSessionData(session);
+
+      if (!userData) {
+        throw new Error('Failed to save user data');
+      }
 
       // Update state
       set({
         isAuthenticated: true,
-        user,
-        accessToken: tokens.access,
-        refreshToken: tokens.refresh,
+        user: userData,
+        accessToken: session.access_token,
+        refreshToken: session.refresh_token,
         error: null
       });
     } catch (error: any) {
@@ -183,6 +161,9 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
   logout: async () => {
     try {
       set({ isLoading: true });
+
+      // Call Supabase logout
+      await supabase.auth.signOut();
 
       // Clear tokens and user data from storage
       await clearTokens();
@@ -208,22 +189,19 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
   // Refresh tokens method
   refreshTokens: async () => {
     try {
-      const { refreshToken } = get();
+      const session = await refreshSession();
 
-      if (!refreshToken) {
+      if (!session) {
         return false;
       }
 
-      // Call refresh token API (mock for now)
-      const tokens = await mockRefreshToken(refreshToken);
-
       // Save new tokens
-      await saveTokens(tokens.access, tokens.refresh);
+      await saveTokens(session.access_token, session.refresh_token);
 
       // Update state
       set({
-        accessToken: tokens.access,
-        refreshToken: tokens.refresh
+        accessToken: session.access_token,
+        refreshToken: session.refresh_token
       });
 
       return true;

--- a/store/language/index.ts
+++ b/store/language/index.ts
@@ -45,5 +45,5 @@ export const useLanguageStore = create<LanguageState>((set, get) => ({
       i18next.changeLanguage('en');
       set({ language: 'en', isInitialized: true });
     }
-  },
+  }
 }));

--- a/store/language/types.ts
+++ b/store/language/types.ts
@@ -15,5 +15,5 @@ export interface LanguageOption {
 
 export const LANGUAGE_OPTIONS: LanguageOption[] = [
   { code: 'en', name: 'English', flag: '🇺🇸' },
-  { code: 'es', name: 'Español', flag: '🇪🇸' },
+  { code: 'es', name: 'Español', flag: '🇪🇸' }
 ];

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,7 +4,7 @@ module.exports = {
 
   presets: [require('nativewind/preset')],
   theme: {
-    extend: {},
+    extend: {}
   },
-  plugins: [],
+  plugins: []
 };

--- a/utilities/supabase.ts
+++ b/utilities/supabase.ts
@@ -1,14 +1,28 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import { createClient } from '@supabase/supabase-js';
+import { isWeb } from '@utilities/platform';
+import * as SecureStore from 'expo-secure-store';
 
 const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL as string;
 const supabaseAnonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY as string;
 
+// Custom storage implementation for React Native using SecureStore
+const ExpoSecureStoreAdapter = {
+  getItem: (key: string) => {
+    return SecureStore.getItemAsync(key);
+  },
+  setItem: (key: string, value: string) => {
+    return SecureStore.setItemAsync(key, value);
+  },
+  removeItem: (key: string) => {
+    return SecureStore.deleteItemAsync(key);
+  }
+};
+
 export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
   auth: {
-    storage: AsyncStorage,
+    storage: isWeb ? localStorage : ExpoSecureStoreAdapter,
     autoRefreshToken: true,
     persistSession: true,
-    detectSessionInUrl: false
+    detectSessionInUrl: isWeb
   }
 });

--- a/utils/supabase.ts
+++ b/utils/supabase.ts
@@ -9,6 +9,6 @@ export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
     storage: AsyncStorage,
     autoRefreshToken: true,
     persistSession: true,
-    detectSessionInUrl: false,
-  },
+    detectSessionInUrl: false
+  }
 });


### PR DESCRIPTION
- Add OAuth sign-in methods for Apple and Google
- Create auth callback screen to handle OAuth redirects
- Update AuthProvider to manage Supabase auth state changes
- Configure app.json with app scheme and bundle identifiers
- Refactor auth store to use Supabase authentication methods
- Add Expo Web Browser for OAuth session handling
- Remove mock authentication implementations
- Linting fixes